### PR TITLE
Cropper button type defined as 'button'

### DIFF
--- a/projects/file-picker/src/lib/file-picker.component.html
+++ b/projects/file-picker/src/lib/file-picker.component.html
@@ -32,11 +32,12 @@
     (load)="cropperImgLoaded($event)"
   />
   <div class="cropper-actions">
-    <button class="cropSubmit" (click)="onCropSubmit()">
+    <button class="cropSubmit" (click)="onCropSubmit()" type="button">
       {{ captions?.cropper?.crop }}
     </button>
     <button
       class="cropCancel"
+      type="button"
       (click)="
         closeCropper({
           file: currentCropperFile,


### PR DESCRIPTION
As discussed in pull request #61 added explicit button type="button" to stop form from being submitted pre-maturely.